### PR TITLE
Pass additional arguments as options to dragula JS function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dragulaR
 Type: Package
 Title: Drag and Drop Elements in 'Shiny' using 'Dragula Javascript Library'
-Version: 0.3.1
+Version: 0.3.2
 Authors@R: c(person("Nicolas", "Bevacqua", role = c("aut", "cph"),
        comment = "dragula library in htmlwidgets/lib, https://github.com/bevacqua/dragula"),
        person("Zygmunt", "Zawadzki", role = c("aut", "cre"),

--- a/R/dragula.R
+++ b/R/dragula.R
@@ -21,7 +21,6 @@
 #'
 dragula <- function(x, ...) {
 
-  message('This is your custom dragulaR instance speaking...')
   if(!is.character(x))
   {
     stop("x must be a character vector!")
@@ -36,6 +35,7 @@ dragula <- function(x, ...) {
   width  = "0px"
   height = "0px"
 
+  # shortcut option for allowing copying from a single container
   if ('copyOnly' %in% names(settings)) {
     container <- settings[['copyOnly']]
     settings[['copy']] <- JS("function(el, source) { ",

--- a/R/dragula.R
+++ b/R/dragula.R
@@ -18,21 +18,38 @@
 #'   runApp(path, display.mode = "showcase")
 #' }
 #'
-dragula <- function(x, id = NULL) {
+dragula <- function(x, ...) {
 
+  message('This is your custom dragulaR instance speaking...')
   if(!is.character(x))
   {
     stop("x must be a character vector!")
   }
+
+  settings = list(...)
+  id <- settings[['id']]
+  settings[['id']] <- NULL
 
   names(x) = NULL
 
   width  = "0px"
   height = "0px"
 
+  if ('copyOnly' %in% names(settings)) {
+    container <- settings[['copyOnly']]
+    settings[['copy']] <- JS("function(el, source) { ",
+                             paste0("return source === document.getElementById('", container, "');"),
+                             "}")
+    settings[['accepts']] <- JS("function(el, target) {",
+                                paste0("return target !== document.getElementById('", container, "');"),
+                                "}")
+    settings[['copyOnly']] <- NULL
+  }
+
   # forward options using x
   x = list(
     x = x,
+    settings = settings,
     elid = id
   )
 

--- a/R/dragula.R
+++ b/R/dragula.R
@@ -4,6 +4,7 @@
 #'
 #' @param x vector of containers ids. Their's elements will become draggable.
 #' @param id input id to read from in shiny.
+#' @param ... additonal arguments passed to dragula JS as options.
 #'
 #' @importFrom htmlwidgets createWidget shinyWidgetOutput shinyRenderWidget
 #' @import shiny

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ runApp(
   display.mode = "showcase")
 ```
 
+### Pass options to `dragula`
+
+See [dragula README][https://github.com/bevacqua/dragula#dragulacontainers-options] for valid options. 
+
+```r
+runApp(
+  system.file("apps/example07-dragula-input-options", package = "dragulaR"),
+  display.mode = "showcase")
+```
+
 ### All examples
 
 ```r
@@ -59,4 +69,5 @@ dir(system.file("apps/", package = "dragulaR"))
 # example04-dragula-module
 # example05-dragula-dynamic-elements
 # example06-dragula-dynamic-elements-renderUI
+# example07-dragula-input-options
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ runApp(
 
 ### Pass options to `dragula`
 
-See [dragula README][https://github.com/bevacqua/dragula#dragulacontainers-options] for valid options. 
+See [dragula README](https://github.com/bevacqua/dragula#dragulacontainers-options) for valid options. 
 
 ```r
 runApp(

--- a/inst/apps/example05-dragula-dynamic-elements/app.R
+++ b/inst/apps/example05-dragula-dynamic-elements/app.R
@@ -10,7 +10,7 @@ ui <- fluidPage(
         actionButton("Add", label = "Add"),
         fluidRow(id = "elements",
                  div(id = "placeholder")),
-        dragula("elements", id = "dragula")
+        dragula("elements", id = "dragula", removeOnSpill = TRUE)
 )
 
 server <- function(input, output) {

--- a/inst/apps/example07-input-options/app.R
+++ b/inst/apps/example07-input-options/app.R
@@ -1,0 +1,59 @@
+library(shiny)
+
+makeElement <- function(data, name)
+{
+  div(style = "border-width:2px;border-style:solid;",
+    drag = name,
+    div(class = "active title", name),
+    div(class = "active content", p(sprintf("Class: %s", class(data[[name]])))))
+}
+
+ui <- fluidPage(
+  titlePanel("Drag and drop elements with dragulaR"),
+  fluidRow(style = "margin: 15px;",
+    column(3,
+      h3("Drag from here:"),
+      div(id = "Available", style = "min-height: 600px;",
+        lapply(colnames(mtcars), makeElement, data = mtcars))
+    ),
+    column(3,
+      h3("Drop here:"),
+      div(id = "Model", style = "min-height: 600px;")
+    ),
+    column(6,
+      plotOutput("plot"),
+      verbatimTextOutput("print")
+    )
+  ),
+  dragulaOutput("dragula")
+
+)
+
+server <- function(input, output) {
+  output$dragula <- renderDragula({
+    dragula(c("Available", "Model"),
+            #copy = JS("function(el, source) { return source === document.getElementById('Available'); }"),
+            #accepts = JS("function(el, target) { return target !== document.getElementById('Available'); }"),
+            copyOnly = 'Available', # shortcut for allowing copy from only a single container, i.e. implements commented options above.
+            removeOnSpill = TRUE)
+  })
+
+  output$plot <- renderPlot({
+    req(input$dragula)
+    state <- dragulaValue(input$dragula)
+    validate(need(length(state$Model) > 1, message = "Please select at least two variables."))
+
+    plot(mtcars[,state$Model])
+  })
+
+  output$print <- renderText({
+    state <- dragulaValue(input$dragula)
+    sprintf("Available:\n  %s\n\nModel:\n  %s",
+            paste(state$Available, collapse = ", "),
+            paste(state$Model, collapse = ", "))
+
+  })
+
+}
+
+shinyApp(ui = ui, server = server)

--- a/inst/htmlwidgets/dragula.js
+++ b/inst/htmlwidgets/dragula.js
@@ -1,10 +1,15 @@
 HTMLWidgets.widget({
 
-  name: 'dragula',
+  name: "dragula",
 
-  type: 'output',
+  type: "output",
 
     factory: function(el, width, height) {
+
+        var instance = {
+            drag: dragula(),
+            id: el.id
+        };
 
         var shinyInputChange = function (el) {
             var result = {};
@@ -12,12 +17,12 @@ HTMLWidgets.widget({
                 var container = instance.drag.containers[i];
                 var res = [];
                 document
-          .querySelectorAll("#" + container.getAttribute('id') + ' > [drag]')
+          .querySelectorAll("#" + container.getAttribute("id") + " > [drag]")
           .forEach(function(x, id) { res[id] = x.getAttribute("drag");});
                 result[container.getAttribute('id')] = res;
             }
 
-            if (typeof Shiny.onInputChange !== 'undefined') {
+            if (typeof Shiny.onInputChange !== "undefined") {
                 Shiny.onInputChange(instance.id, result);
             }
         };
@@ -29,11 +34,6 @@ HTMLWidgets.widget({
             el.removeChild(el.firstChild);
         }
 
-        var instance = {
-            drag: dragula(),
-            id: el.id
-        };
-
         return {
             renderValue: function(x) {
                 if (x.settings !== null) {
@@ -42,8 +42,8 @@ HTMLWidgets.widget({
                         instance.drag = null;
                     }
                     instance.drag = dragula(x.settings)
-                                             .on('drop', shinyInputChange)
-                                             .on('remove', shinyInputChange);
+                                             .on("drop", shinyInputChange)
+                                             .on("remove", shinyInputChange);
                 }
 
                 if (typeof x.elid !== "undefined" && x.elid !== null) {
@@ -65,16 +65,16 @@ HTMLWidgets.widget({
                     }
                 }
 
-                if (typeof Shiny === 'undefined') {
-                    $(document).on('shiny:connected', function(event) {
-                        if(typeof dragulaR === 'undefined') {
+                if (typeof Shiny === "undefined") {
+                    $(document).on("shiny:connected", function(event) {
+                        if(typeof dragulaR === "undefined") {
                             dragulaR = new Map();
                         }
                         dragulaR.set(instance.id, shinyInputChange);
                         shinyInputChange(el);
                     });
                 } else {
-                    if(typeof dragulaR === 'undefined') {
+                    if(typeof dragulaR === "undefined") {
                         dragulaR = new Map();
                     }
                     dragulaR.set(instance.id, shinyInputChange);

--- a/inst/htmlwidgets/dragula.js
+++ b/inst/htmlwidgets/dragula.js
@@ -4,98 +4,89 @@ HTMLWidgets.widget({
 
   type: 'output',
 
-      initialize: function(el, width, height) {
-        return {};
-      },
+    factory: function(el, width, height) {
 
-      renderValue: function(el, x, instance) {
+        var shinyInputChange = function (el) {
+            var result = {};
+            for(var i = 0; i < instance.drag.containers.length; i++) {
+                var container = instance.drag.containers[i];
+                var res = [];
+                document
+          .querySelectorAll("#" + container.getAttribute('id') + ' > [drag]')
+          .forEach(function(x, id) { res[id] = x.getAttribute("drag");});
+                result[container.getAttribute('id')] = res;
+            }
 
-        if(instance.drag !== null)
-        {
-          // remove old instance of dragula
-          instance.drag = null;
-          instance.id   = null;
-        }
-
-        while(el.firstChild)
-        {
-          // remove old divs inside this object
-          el.removeChild(el.firstChild);
-        }
-
-
-        // this code is used when x.x was created from string vector
-        // in that case - values from that vector will be treated as a
-        // elments' ids, and they will be pushed into dragula.
-
-        instance.drag = dragula();
-
-
-        if (typeof x.elid !== 'undefined' && x.elid !== null) {
-          instance.id = x.elid;
-        } else {
-          instance.id = el.id;
-        }
-
-        var ids = x.x;
-
-        // hack when ids is just single string
-        if(!Array.isArray(ids))
-        {
-          instance.drag.containers.push(document.getElementById(ids));
-        } else {
-          for(var i = 0; i < ids.length; i++)
-          {
-            instance.drag.containers.push(document.getElementById(ids[i]));
-          }
-        }
-
-
-
-        var onDrop = function (el) {
-
-          var result = {}
-
-          for(var i = 0; i < instance.drag.containers.length; i++) {
-
-            var container = instance.drag.containers[i];
-            var res = [];
-            document
-              .querySelectorAll("#" + container.getAttribute('id') + ' > [drag]')
-              .forEach(function(x, id) { res[id] = x.getAttribute("drag");});
-
-
-            result[container.getAttribute('id')] = res;
-          }
-
-          if (typeof Shiny.onInputChange !== 'undefined') {
-            Shiny.onInputChange(instance.id, result);
-          }
+            if (typeof Shiny.onInputChange !== 'undefined') {
+                Shiny.onInputChange(instance.id, result);
+            }
         };
 
-         if (typeof Shiny === 'undefined') {
-           $(document).on('shiny:connected', function(event) {
-              if(typeof dragulaR === 'undefined') {
-                dragulaR = new Map();
-              }
-              dragulaR.set(instance.id, onDrop);
-              onDrop(el);
-              instance.drag.on('drop', onDrop);
-            });
-         } else {
-           if(typeof dragulaR === 'undefined') {
-                dragulaR = new Map();
-           }
-           dragulaR.set(instance.id, onDrop);
-           onDrop(el);
-           instance.drag.on('drop', onDrop);
-         }
+        // Is this necessary? Does dragula even use this element for anything?
+        while(el.firstChild)
+        {
+            // remove old divs inside this object
+            el.removeChild(el.firstChild);
+        }
 
+        var instance = {
+            drag: dragula(),
+            id: el.id
+        };
 
+        return {
+            renderValue: function(x) {
+                if (x.settings !== null) {
+                    if (instance.drag !== null) {
+                        instance.drag.destroy();
+                        instance.drag = null;
+                    }
+                    instance.drag = dragula(x.settings)
+                                             .on('drop', shinyInputChange)
+                                             .on('remove', shinyInputChange);
+                }
 
-      },
+                if (typeof x.elid !== "undefined" && x.elid !== null) {
+                    instance.id = x.elid;
+                } else {
+                    instance.id = el.id;
+                }
 
-      resize: function(width, height) {
-      }
+                var ids = x.x;
 
+                // hack when ids is just single string
+                if(!Array.isArray(ids))
+                {
+                    instance.drag.containers.push(document.getElementById(ids));
+                } else {
+                    for(var i = 0; i < ids.length; i++)
+                    {
+                        instance.drag.containers.push(document.getElementById(ids[i]));
+                    }
+                }
+
+                if (typeof Shiny === 'undefined') {
+                    $(document).on('shiny:connected', function(event) {
+                        if(typeof dragulaR === 'undefined') {
+                            dragulaR = new Map();
+                        }
+                        dragulaR.set(instance.id, shinyInputChange);
+                        shinyInputChange(el);
+                    });
+                } else {
+                    if(typeof dragulaR === 'undefined') {
+                        dragulaR = new Map();
+                    }
+                    dragulaR.set(instance.id, shinyInputChange);
+                    shinyInputChange(el);
+                }
+
+            },
+
+            resize: function(width, height) {
+            },
+
+            drag: instance.drag
+        };
+    }
 });


### PR DESCRIPTION
Any additional arguments supplied to the dragula R function will be passed as options to the dragula JS function. As an example, this allows easy setting of the 'copy' option to allow copying dragable options instead of moving them.

Additionally, the htmlwidgets implementation was updated to use the [newer API](http://www.htmlwidgets.org/develop_intro.html#javascript-binding).